### PR TITLE
Add nullableFromBijection and clean up other Nullable instances

### DIFF
--- a/smithy4s/src/main/smithy/Test.smithy
+++ b/smithy4s/src/main/smithy/Test.smithy
@@ -2,6 +2,7 @@ $version: "2.0"
 namespace com.dwolla.test
 
 string MySmithy4sNewtype
+integer Smithy4sPrimitiveNewtype
 
 list MyList {
     member: String

--- a/src/main/scala/com/dwolla/testutils/jdbc/OptionsToNull.scala
+++ b/src/main/scala/com/dwolla/testutils/jdbc/OptionsToNull.scala
@@ -60,40 +60,39 @@ sealed trait Nullable[A] { outer =>
 }
 
 private sealed trait SafeNullable[A] extends Nullable[A] {
-  override type B >: Null
+  override type B <: AnyRef
 }
 
 object Nullable extends Smithy4sNullableInstances {
   type Aux[A, B1] = Nullable[A] { type B = B1 }
   def apply[A](implicit ev: Nullable[A]): ev.type = ev
 
-  implicit val nullableChar: Nullable.Aux[Char, java.lang.Character] = makeConversion(char2Character)
-  implicit val nullableShort: Nullable.Aux[Short, java.lang.Short] = makeConversion(short2Short)
-  implicit val nullableInt: Nullable.Aux[Int, java.lang.Integer] = makeConversion(int2Integer)
-  implicit val nullableFloat: Nullable.Aux[Float, java.lang.Float] = makeConversion(float2Float)
-  implicit val nullableLong: Nullable.Aux[Long, java.lang.Long] = makeConversion(long2Long)
-  implicit val nullableDouble: Nullable.Aux[Double, java.lang.Double] = makeConversion(double2Double)
-  implicit val nullableBoolean: Nullable.Aux[Boolean, java.lang.Boolean] = makeConversion(boolean2Boolean)
-  implicit val nullableByte: Nullable.Aux[Byte, java.lang.Byte] = makeConversion(byte2Byte)
-
-  implicit def nullableAnyRef[A >: Null]: Nullable.Aux[A, A] = new SafeNullable[A] {
+  @deprecated("use nullableAnyRefViaConversion", "0.1.1") val nullableChar: Nullable.Aux[Char, java.lang.Character] = makeConversion(char2Character)
+  @deprecated("use nullableAnyRefViaConversion", "0.1.1") val nullableShort: Nullable.Aux[Short, java.lang.Short] = makeConversion(short2Short)
+  @deprecated("use nullableAnyRefViaConversion", "0.1.1") val nullableInt: Nullable.Aux[Int, java.lang.Integer] = makeConversion(int2Integer)
+  @deprecated("use nullableAnyRefViaConversion", "0.1.1") val nullableFloat: Nullable.Aux[Float, java.lang.Float] = makeConversion(float2Float)
+  @deprecated("use nullableAnyRefViaConversion", "0.1.1") val nullableLong: Nullable.Aux[Long, java.lang.Long] = makeConversion(long2Long)
+  @deprecated("use nullableAnyRefViaConversion", "0.1.1") val nullableDouble: Nullable.Aux[Double, java.lang.Double] = makeConversion(double2Double)
+  @deprecated("use nullableAnyRefViaConversion", "0.1.1") val nullableBoolean: Nullable.Aux[Boolean, java.lang.Boolean] = makeConversion(boolean2Boolean)
+  @deprecated("use nullableAnyRefViaConversion", "0.1.1") val nullableByte: Nullable.Aux[Byte, java.lang.Byte] = makeConversion(byte2Byte)
+  @deprecated("use nullableAnyRefViaConversion", "0.1.1") def nullableAnyRef[A <: AnyRef]: Nullable.Aux[A, A] = new SafeNullable[A] {
     override type B = A
     override val f: A => B = identity
   }
 
-  private[jdbc] def makeConversion[A, B1 >: Null](f1: A => B1): Nullable.Aux[A, B1] = new SafeNullable[A] {
+  implicit def nullableAnyRefViaConversion[A, BB <: AnyRef](implicit ff: A => BB): Nullable.Aux[A, BB] =
+    new SafeNullable[A] {
+      override type B = BB
+      override val f: A => BB = ff
+    }
+
+  private[jdbc] def makeConversion[A, B1 <: AnyRef](f1: A => B1): Nullable.Aux[A, B1] = new SafeNullable[A] {
     override type B = B1
     override val f: A => B = f1
   }
 
-  implicit def nullableFromBijection[A >: Null, BB <: Newtype[A]#Type](implicit B: Bijection[A, BB]): Nullable.Aux[BB, A] =
-    new SafeNullable[BB] {
-      override type B = A
-      override val f: BB => A = implicitly[Bijection[A, BB]].from
-    }
-
-  implicit def nullableFromPrimitiveBijection[A, BB <: Newtype[A]#Type, C >: Null](implicit B: Bijection[A, BB],
-                                                                                   C: A => C): Nullable.Aux[BB, C] =
+  implicit def nullableFromBijection[A, BB <: Newtype[A]#Type, C <: AnyRef](implicit B: Bijection[A, BB],
+                                                                            C: A => C): Nullable.Aux[BB, C] =
     makeConversion((implicitly[Bijection[A, BB]].from _).andThen(C))
 }
 

--- a/src/test/scala/com/dwolla/testutils/jdbc/NullableSpec.scala
+++ b/src/test/scala/com/dwolla/testutils/jdbc/NullableSpec.scala
@@ -9,21 +9,22 @@ class NullableSpec
   extends ScalaCheckSuite
     with Smithy4sArbitraries {
 
-  testSchemaType[MySmithy4sNewtype]("Empty newtypes are mapped to null")
-  testSchemaType[MyList]("Empty lists are mapped to null")
-  testSchemaType[MyMap]("Empty maps are mapped to null")
-  testSchemaType[MyStructure]("Empty structures are mapped to null")
-  testSchemaType[MyUnion]("Empty unions are mapped to null")
-  testSchemaType[MyEnum]("Empty enums are mapped to null")
-  testSchemaType[MyRecursive]("Empty recursive structures are mapped to null")
+  testSchemaType[MySmithy4sNewtype]("Empty newtypes are mapped to null via Schema")
+  testSchemaType[MyList]("Empty lists are mapped to null via Schema")
+  testSchemaType[MyMap]("Empty maps are mapped to null via Schema")
+  testSchemaType[MyStructure]("Empty structures are mapped to null via Schema")
+  testSchemaType[MyUnion]("Empty unions are mapped to null via Schema")
+  testSchemaType[MyEnum]("Empty enums are mapped to null via Schema")
+  testSchemaType[MyRecursive]("Empty recursive structures are mapped to null via Schema")
 
-  testBijectionType(MySmithy4sNewtype)("Empty newtypes are mapped to null")
-  testBijectionType(MyList)("Empty lists are mapped to null")
-  testBijectionType(MyMap)("Empty maps are mapped to null")
-  testNullableType[MyStructure]("Empty structures are mapped to null")
-  testNullableType[MyUnion]("Empty unions are mapped to null")
-  testNullableType[MyEnum]("Empty enums are mapped to null")
-  testNullableType[MyRecursive]("Empty recursive structures are mapped to null")
+  testBijectionType(MySmithy4sNewtype)("Empty newtypes are mapped to null via Bijection")
+  testBijectionType(MyList)("Empty lists are mapped to null via Bijection")
+  testBijectionType(MyMap)("Empty maps are mapped to null via Bijection")
+
+  testNullableType[MyStructure]("Empty structures are mapped to null via nullableAnyRef")
+  testNullableType[MyUnion]("Empty unions are mapped to null via nullableAnyRef")
+  testNullableType[MyEnum]("Empty enums are mapped to null via nullableAnyRef")
+  testNullableType[MyRecursive]("Empty recursive structures are mapped to null via nullableAnyRef")
 
   private implicit def optionSchema[A : Schema]: Schema[Option[A]] = Schema.option(Schema[A])
 

--- a/src/test/scala/com/dwolla/testutils/jdbc/OptionsToNullSpec.scala
+++ b/src/test/scala/com/dwolla/testutils/jdbc/OptionsToNullSpec.scala
@@ -11,7 +11,8 @@ class OptionsToNullSpec
     with Smithy4sArbitraries {
 
   test("Empty options in HLists are mapped to null") {
-    case class Smithy4sExamples(maybeSmithy4sNewType: Option[MySmithy4sNewtype],
+    case class Smithy4sExamples(maybeSmithy4sPrimitiveNewtype: Option[Smithy4sPrimitiveNewtype],
+                                maybeSmithy4sNewType: Option[MySmithy4sNewtype],
                                 maybeList: Option[MyList],
                                 maybeMap: Option[MyMap],
                                 maybeStruct: Option[MyStructure],
@@ -22,6 +23,7 @@ class OptionsToNullSpec
     object Smithy4sExamples {
       implicit val arbSmithy4sExamples: Arbitrary[Smithy4sExamples] = Arbitrary {
         for {
+          maybeSmithy4sPrimitiveNewtype <- arbitrary[Option[Smithy4sPrimitiveNewtype]]
           maybeSmithy4sNewType <- arbitrary[Option[MySmithy4sNewtype]]
           maybeList <- arbitrary[Option[MyList]]
           maybeMap <- arbitrary[Option[MyMap]]
@@ -29,7 +31,7 @@ class OptionsToNullSpec
           maybeUnion <- arbitrary[Option[MyUnion]]
           maybeEnum <- arbitrary[Option[MyEnum]]
           maybeMyRecursive <- arbitrary[Option[MyRecursive]]
-        } yield Smithy4sExamples(maybeSmithy4sNewType, maybeList, maybeMap, maybeStruct, maybeUnion, maybeEnum, maybeMyRecursive)
+        } yield Smithy4sExamples(maybeSmithy4sPrimitiveNewtype, maybeSmithy4sNewType, maybeList, maybeMap, maybeStruct, maybeUnion, maybeEnum, maybeMyRecursive)
       }
     }
 
@@ -42,9 +44,10 @@ class OptionsToNullSpec
                           ) =>
       val input =
         maybeInt ::
+          smithy4sExamples.maybeSmithy4sPrimitiveNewtype ::
+          smithy4sExamples.maybeSmithy4sNewType ::
           maybeString ::
           maybeInteger ::
-          smithy4sExamples.maybeSmithy4sNewType ::
           smithy4sExamples.maybeList ::
           smithy4sExamples.maybeMap ::
           smithy4sExamples.maybeStruct ::
@@ -59,9 +62,10 @@ class OptionsToNullSpec
 
       val expected =
         maybeInt.fold[Integer](null)(identity) ::
+          smithy4sExamples.maybeSmithy4sPrimitiveNewtype.fold[Integer](null)(_.value) ::
+          smithy4sExamples.maybeSmithy4sNewType.fold[String](null)(_.value) ::
           maybeString.fold[String](null)(identity) ::
           maybeInteger.fold[Integer](null)(identity) ::
-          smithy4sExamples.maybeSmithy4sNewType.fold[String](null)(_.value) ::
           smithy4sExamples.maybeList.fold[List[String]](null)(_.value) ::
           smithy4sExamples.maybeMap.fold[Map[String, Int]](null)(_.value) ::
           smithy4sExamples.maybeStruct.fold[MyStructure](null)(identity) ::

--- a/src/test/scala/com/dwolla/testutils/jdbc/Smithy4sArbitraries.scala
+++ b/src/test/scala/com/dwolla/testutils/jdbc/Smithy4sArbitraries.scala
@@ -12,6 +12,9 @@ trait Smithy4sArbitraries {
   implicit val arbMySmithy4sNewtype: Arbitrary[MySmithy4sNewtype] =
     Arbitrary(arbitrary[String].map(MySmithy4sNewtype(_)))
 
+  implicit val arbSmithy4sPrimitiveNewtype: Arbitrary[Smithy4sPrimitiveNewtype] =
+    Arbitrary(arbitrary[Int].map(Smithy4sPrimitiveNewtype(_)))
+
   implicit val arbMyList: Arbitrary[MyList] =
     Arbitrary(arbitrary[List[String]].map(MyList(_)))
 


### PR DESCRIPTION
Using `Bijection[A, B]` instead of `Schema[A]` lets us leverage the `B >: Null` condition in more places. (The `Schema[A]` instance is really only left behind to maintain binary compatibility, but I didn't deprecate it because it's possible that it might be useful; idk.)

I wanted to push the `orNull` implementation down into `SafeNullable` and an `UnsafeNullable` that isn't present in this PR, but since I made `orNull` `final`, that caused binary compatibility issues. (The implementation in `SafeNullable` would not have required the `asInstanceOf` cast, but otherwise the implementations would have been the same.)